### PR TITLE
Data from Etherscan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.env
+package-lock.json
+node_modules/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+#zelagac

--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
 #zelagac
+
+ZEroLAbs GAs Consumption. The goal is to fetch the data consonsumption for any given smart contract until [Ethereum's merge from PoW to PoS](https://www.investopedia.com/the-ethereum-merge-6504132). This consumption should be split up by day and type of transaction (inbound, outbound and internal).
+
+## Etherscan approach
+
+Fetch the data from the [Etherscan API](https://etherscan.io/apis). To make it work, first create an etherscan API key, then store it under a `.env` file containing a line `ETHERSCAN_API_KEY="YOUR_API_KEY"`. A free API access is enough (as for the time writing this).
+
+The function `getEtherscanData()` in [src/fetcher.js](src/fetcher.js) then executes the queries fetching the data.
+
+## Web server
+
+Just run `node app/server.js` in a terminal window to run the web server, that will then run on port `3000` of `localhost`, as defined in [app/server.js](app/server.js). From there, you can get the data for a specific contract with e.g. following query: `http://localhost:3000/etherscanContractConsumption?contractAddress=0x283af0b28c62c092c9727f1ee09c02ca627eb7f5`. The endpoint is `etherscanContractConsumption` taking `contractAdress` as query parameter.
+
+## test
+
+Just run `npm test`.

--- a/app/server.js
+++ b/app/server.js
@@ -1,0 +1,12 @@
+var express = require("express");
+var app = express();
+
+var fetcher = require("../src/fetcher");
+
+app.get("/etherscanContractConsumption", function(req, res) {
+    var contractAddress = req.query.contractAddress;
+    var gasConsumption = fetcher.getEtherscanData(contractAddress);
+    res.send(gasConsumption); // JSON.stringify() or something like that?
+});
+
+app.listen(3000);

--- a/app/server.js
+++ b/app/server.js
@@ -3,10 +3,10 @@ var app = express();
 
 var fetcher = require("../src/fetcher");
 
-app.get("/etherscanContractConsumption", function(req, res) {
+app.get("/etherscanContractConsumption", async (req, res) => {
     var contractAddress = req.query.contractAddress;
     var gasConsumption = fetcher.getEtherscanData(contractAddress);
-    res.send(gasConsumption); // JSON.stringify() or something like that?
+    res.json(gasConsumption);
 });
 
 app.listen(3000);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "zelagac",
+  "version": "1.0.0",
+  "description": "zelagac: ZEroLAbs GAs Consumption",
+  "main": "main.js",
+  "scripts": {
+    "test": "mocha --reporter spec"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mancap314/zelagac.git"
+  },
+  "keywords": [
+    "ethereum",
+    "smart-contracts",
+    "gas",
+    "consumption"
+  ],
+  "author": "Manuel Capel",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/mancap314/zelagac/issues"
+  },
+  "homepage": "https://github.com/mancap314/zelagac#readme",
+  "dependencies": {
+    "chai": "^4.3.7",
+    "dotenv": "^16.0.3",
+    "express": "^4.18.2",
+    "mocha": "^10.2.0",
+    "request": "^2.88.2",
+    "xmlhttprequest": "^1.8.0"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/mancap314/zelagac.git"
+    "url": "git+https://github.com/zerolabsgreen/ethereum-historical-gas.git"
   },
   "keywords": [
     "ethereum",
@@ -19,9 +19,9 @@
   "author": "Manuel Capel",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/mancap314/zelagac/issues"
+    "url": "https://github.com/zerolabsgreen/ethereum-historical-gas/issues"
   },
-  "homepage": "https://github.com/mancap314/zelagac#readme",
+  "homepage": "https://github.com/zerolabsgreen/ethereum-historical-gas#readme",
   "dependencies": {
     "chai": "^4.3.7",
     "dotenv": "^16.0.3",

--- a/src/fetcher.js
+++ b/src/fetcher.js
@@ -1,5 +1,4 @@
 var dotenv = require("dotenv");
-var XMLHttpRequest = require("xmlhttprequest").XMLHttpRequest;
 
 dotenv.config()
 

--- a/src/fetcher.js
+++ b/src/fetcher.js
@@ -1,4 +1,5 @@
 var dotenv = require("dotenv");
+var XMLHttpRequest = require("xmlhttprequest").XMLHttpRequest;
 
 dotenv.config()
 
@@ -12,18 +13,31 @@ function encodeQueryData(data) {
     return ret.join('&');
  }
 
- function process_etherscan_response(resp, queryType) {
+function process_etherscan_response(resp, queryType) {
+    gas_consumption = {};
     console.log("process_etherscan_response(), queryType: " + queryType);
-    console.log("resp:" + resp);
+    const json_resp = JSON.parse(resp);
+    if (json_resp["status"] != 1) {
+        console.log("[ERROR] Problem with response: " + json_resp["message"]);
+        return gas_consumption;
+    }
+    const tx_list = json_resp["result"];
+    tx_list.forEach((tx, _) => {
+        ts = tx["timeStamp"];
+        var dateFormat = new Date(ts * 1000);
+        var dateStr = dateFormat.getUTCFullYear() + "-" + (dateFormat.getUTCMonth() + 1) + "-" + dateFormat.getUTCDate();
+        if (!(dateStr in gas_consumption)) gas_consumption[dateStr] = {"gasUsed": 0};
+        gas_consumption[dateStr]["gasUsed"] += parseInt(tx["gasUsed"]);
+    });
+    return gas_consumption;
  }
  
 
-exports.getEtherscanData = (contractAddress) => {
+function getEtherscanData(contractAddress) {
     etherscan_api_key = process.env.ETHERSCAN_API_KEY;
 
     queryData = { 
         "module": "account", 
-        "action": "txlist", 
         "address": contractAddress, 
         "startblock": 0, 
         "endblock": 15537393, 
@@ -31,15 +45,25 @@ exports.getEtherscanData = (contractAddress) => {
         "apikey": etherscan_api_key 
     };
 
-    queryString = encodeQueryData(queryData);
-    queryUrl = [url, queryString].join("?");
+    etherscan_gas_consumption = {};
+    actions = ["txlist", "txlistinternal"];
+    actions.forEach( (action, _) => {
+        queryData["action"] = action;
+        queryString = encodeQueryData(queryData);
+        queryUrl = [url, queryString].join("?");
 
-    var xmlHttp = new XMLHttpRequest();
-    xmlHttp.onreadystatechange = function() { 
-        if (xmlHttp.readyState == 4 && xmlHttp.status == 200)
-            process_etherscan_response(xmlHttp.responseText, "txlist");
-    }
-    xmlHttp.open("GET", queryUrl, true); // true for asynchronous 
-    xmlHttp.send(null);
+        var xmlHttp = new XMLHttpRequest();
+        xmlHttp.onreadystatechange = function() { 
+            if (xmlHttp.readyState == 4 && xmlHttp.status == 200)
+                var gas_consumption_action = process_etherscan_response(xmlHttp.responseText, action);
+                etherscan_gas_consumption[action] = gas_consumption_action;
+                // return gas_consumption_action;
+        }
+        xmlHttp.open("GET", queryUrl, false); // true for asynchronous
+        xmlHttp.send(null);
+    });
+    
+    return etherscan_gas_consumption;
 };
 
+exports.getEtherscanData = getEtherscanData;

--- a/src/fetcher.js
+++ b/src/fetcher.js
@@ -1,0 +1,46 @@
+var dotenv = require("dotenv");
+var XMLHttpRequest = require("xmlhttprequest").XMLHttpRequest;
+
+dotenv.config()
+
+var url = "https://api.etherscan.io/api"
+
+
+function encodeQueryData(data) {
+    const ret = [];
+    for (let d in data)
+      ret.push(encodeURIComponent(d) + '=' + encodeURIComponent(data[d]));
+    return ret.join('&');
+ }
+
+ function process_etherscan_response(resp, queryType) {
+    console.log("process_etherscan_response(), queryType: " + queryType);
+    console.log("resp:" + resp);
+ }
+ 
+
+exports.getEtherscanData = (contractAddress) => {
+    etherscan_api_key = process.env.ETHERSCAN_API_KEY;
+
+    queryData = { 
+        "module": "account", 
+        "action": "txlist", 
+        "address": contractAddress, 
+        "startblock": 0, 
+        "endblock": 15537393, 
+        "sort": "asc", 
+        "apikey": etherscan_api_key 
+    };
+
+    queryString = encodeQueryData(queryData);
+    queryUrl = [url, queryString].join("?");
+
+    var xmlHttp = new XMLHttpRequest();
+    xmlHttp.onreadystatechange = function() { 
+        if (xmlHttp.readyState == 4 && xmlHttp.status == 200)
+            process_etherscan_response(xmlHttp.responseText, "txlist");
+    }
+    xmlHttp.open("GET", queryUrl, true); // true for asynchronous 
+    xmlHttp.send(null);
+};
+

--- a/test/fetcher.js
+++ b/test/fetcher.js
@@ -1,0 +1,11 @@
+var expect = require("chai").expect;
+var fetcher = require("../src/fetcher");
+
+var testAddress = "0x283af0b28c62c092c9727f1ee09c02ca627eb7f5"
+
+describe("Fetching data from etherscan", () => {
+    it(`Fetching for address ${testAddress}`, (done) => {
+        fetcher.getEtherscanData(testAddress);
+        done();
+    })
+})

--- a/test/fetcher.js
+++ b/test/fetcher.js
@@ -5,7 +5,8 @@ var testAddress = "0x283af0b28c62c092c9727f1ee09c02ca627eb7f5"
 
 describe("Fetching data from etherscan", () => {
     it(`Fetching for address ${testAddress}`, (done) => {
-        fetcher.getEtherscanData(testAddress);
+        var etherscan_gas_consumption = fetcher.getEtherscanData(testAddress);
+        console.log(etherscan_gas_consumption);
         done();
     })
 })

--- a/test/server.js
+++ b/test/server.js
@@ -1,0 +1,24 @@
+var expect = require("chai").expect;
+var request = require("request");
+
+describe("Contract Gas Consumption API", function(){
+    describe("Gas Consumption through Etherscan API", function(){
+
+        var url = "http://localhost:3000/etherscanContractConsumption?contractAddress=0x283af0b28c62c092c9727f1ee09c02ca627eb7f5";
+
+        it("returns status 200", function(done) {
+            request(url, function(error, response, body) {
+                expect(response.statusCode).to.equal(200);
+                done();
+            });
+        });
+        
+        it("returns ... [TO DEFINE]", function(done) {
+            request(url, function(error, response, body) {
+                // expect(body).to.equal("ffffff");
+                done();
+            })
+        });
+    })
+
+})


### PR DESCRIPTION
- Pull data from Etherscan from start until merge for a given contract, group them by type (external and internal) and day for each type
- Create a specific API endpoint for querying this data (to activate through `node app/server.js`, see `README`
- Run test against the generated data, to run  through `npm test` (idem)